### PR TITLE
Infos aus Lieferantenkatalog in Bestellvorlage

### DIFF
--- a/code/views.php
+++ b/code/views.php
@@ -1850,4 +1850,23 @@ function membertable_view( $gruppen_id, $editable = FALSE, $super_edit = FALSE, 
     close_form();
 }
 
+function join_details( &$details, $prefix, $value ) {
+  if ( $value )
+  {
+      $details[] = "$prefix$value";
+  }
+}
+
+
+function catalogue_product_details( $catalogue_record ) {
+  $details = array();
+
+  join_details( $details, '<span title="Herkunft">Hrk:</span> ', 
+          $catalogue_record['herkunft']);
+  join_details( $details, '<span title="Verband">Vbd:</span> ', 
+          $catalogue_record['verband']);
+
+  return join('; ', $details);
+}
+
 ?>

--- a/code/views.php
+++ b/code/views.php
@@ -131,6 +131,26 @@ function string_view( $text, $length = 20, $fieldname = false, $attr = '' ) {
     return "<span class='string'>$text</span>";
 }
 
+function ean_view( $ean, $length = 20, $fieldname = false, $attr = '', $with_links = false ) {
+  global $input_event_handlers;
+  if ( $fieldname )
+    return "<input type='text' class='ean' size='$length' name='$fieldname' value='$ean' $attr $input_event_handlers>";
+  
+  $s = "<span class='ean'>$ean</span> ";
+  if ($with_links)
+    $s .= ean_links ($ean);
+  return $s;
+}
+
+function ean_links( $ean ) {
+  if (!$ean)
+    return '';
+  $s = "<a title='Google' target='_blank' href='http://google.de/search?q=$ean'>[g]</a>";
+  $s .= "<a title='barcoo' target='_blank' href='http://barcoo.com/de/$ean'>[b]</a>";
+  // $s .= "<a target='_blank' href='http://upcdatabase.com/item/$ean'>[u]</a>";
+  return $s;
+}
+
 function date_time_view( $datetime, $fieldname = '' ) {
   global $mysqljetzt;
   if( ! $datetime )
@@ -1861,10 +1881,15 @@ function join_details( &$details, $prefix, $value ) {
 function catalogue_product_details( $catalogue_record ) {
   $details = array();
 
+  join_details( $details, '', $catalogue_record['bemerkung']);
   join_details( $details, '<span title="Herkunft">Hrk:</span> ', 
           $catalogue_record['herkunft']);
   join_details( $details, '<span title="Verband">Vbd:</span> ', 
           $catalogue_record['verband']);
+  join_details( $details, '<span title="Hersteller">Hst:</span> ', 
+          $catalogue_record['hersteller']);
+  join_details( $details, '<span title="European Article Number">EAN</span> ', 
+          ean_links($catalogue_record['ean_einzeln']));
 
   return join('; ', $details);
 }

--- a/code/views.php
+++ b/code/views.php
@@ -1881,6 +1881,9 @@ function join_details( &$details, $prefix, $value ) {
 
 
 function catalogue_product_details( $catalogue_record ) {
+  if( !is_array($catalogue_record) || empty($catalogue_record) )
+    return '';
+  
   $details = array();
 
   join_details( $details, '', $catalogue_record['bemerkung']);

--- a/code/views.php
+++ b/code/views.php
@@ -145,8 +145,10 @@ function ean_view( $ean, $length = 20, $fieldname = false, $attr = '', $with_lin
 function ean_links( $ean ) {
   if (!$ean)
     return '';
-  $s = "<a title='Google' target='_blank' href='http://google.de/search?q=$ean'>[g]</a>";
+  $s = '';
+  $s .= "<a title='codecheck' target='_blank' href='http://www.codecheck.info/product.search?q=$ean'>[c]</a>";
   $s .= "<a title='barcoo' target='_blank' href='http://barcoo.com/de/$ean'>[b]</a>";
+  $s .= "<a title='Google' target='_blank' href='http://google.de/search?q=$ean'>[g]</a>";
   // $s .= "<a target='_blank' href='http://upcdatabase.com/item/$ean'>[u]</a>";
   return $s;
 }

--- a/code/zuordnen.php
+++ b/code/zuordnen.php
@@ -4576,6 +4576,17 @@ function update_database( $version ) {
 
       sql_update( 'leitvariable', array( 'name' => 'database_version' ), array( 'value' => 21 ) );
       logger( 'update_database: update to version 21 successful' );
+      
+  case 21:
+      logger( 'starting update_database: from version 21' );
+
+      doSql( "ALTER TABLE `lieferantenkatalog` ADD COLUMN `hersteller` text not null default '' " );
+      doSql( "ALTER TABLE `lieferantenkatalog` ADD COLUMN `bemerkung` text not null default '' " );
+      doSql( "ALTER TABLE `lieferantenkatalog` ADD COLUMN `ean_einzeln` varchar(15) not null default '' " );
+
+      sql_update( 'leitvariable', array( 'name' => 'database_version' ), array( 'value' => 22 ) );
+      logger( 'update_database: update to version 22 successful' );
+      
 
 /*
 	case n:

--- a/leitvariable.php
+++ b/leitvariable.php
@@ -108,7 +108,7 @@ $leitvariable = array(
   )
 , 'database_version' => array(
     'meaning' => 'Version der Datenbank'
-  , 'default' => '19'
+  , 'default' => '22'
   , 'comment' => 'Bitte den vorgeschlagenen Wert &uuml;bernehmen und nicht manuell &auml;ndern: diese Variable wird bei Upgrades automatisch hochgesetzt!'
   , 'local' => false
   , 'runtime_editable' => 0

--- a/structure.php
+++ b/structure.php
@@ -902,6 +902,24 @@ $tables = array(
       , 'extra' => ''
       )
     )
+    , 'hersteller' => array(
+        'type' => "text"
+      , 'null' => 'NO'
+      , 'default' => ''
+      , 'extra' => ''
+    )
+    , 'bemerkung' => array(
+        'type' => "text"
+      , 'null' => 'NO'
+      , 'default' => ''
+      , 'extra' => ''
+    )
+    , 'ean_einzeln' => array(
+        'type' => "varchar(15)"
+      , 'null' => 'NO'
+      , 'default' => ''
+      , 'extra' => '' 
+    )
     , 'indices' => array(
         'PRIMARY' => array( 'unique' => 1, 'collist' => 'id' )
       , 'secondary' => array( 'unique' => 1, 'collist' => 'lieferanten_id, artikelnummer' )

--- a/windows/artikelsuche.php
+++ b/windows/artikelsuche.php
@@ -195,15 +195,18 @@ open_fieldset( 'small_form', '', $produkt_id ?  "Katalogsuche nach Artikelnummer
       open_th( '', '', 'A-Nr.' );
       open_th( '', '', 'B-Nr.' );
       open_th( '', '', 'Bezeichnung' );
+      open_th( '', '', 'Bemerkung' );
       open_th( '', '', 'Gebinde' );
       open_th( '', '', 'Einheit' );
       open_th( '', '', 'Land' );
       open_th( '', '', 'Verband' );
+      open_th( '', '', 'Hersteller' );
       open_th( '', '', 'Netto' );
       if( $have_mwst ) {
         open_th( '', '', 'MWSt' );
         open_th( '', '', 'Brutto' );
       }
+      open_th( '', '', 'EAN einzeln');
       open_th( '', '', 'Katalog' );
       if( ! $produkt_id ) {
         open_th( '', '', 'Foodsoft-Datenbank' );
@@ -222,10 +225,12 @@ open_fieldset( 'small_form', '', $produkt_id ?  "Katalogsuche nach Artikelnummer
             }
           open_td( 'number', '', $row['bestellnummer'] );
           open_td( '', '', $row['name'] );
+          open_td( '', '', $row['bemerkung'] );
           open_td( '', '', mult_view( $row['gebinde'] ) );
           open_td( 'unit', '', $row['liefereinheit'] );
           open_td( '', '', $row['herkunft'] );
           open_td( '', '', $row['verband'] );
+          open_td( '', '', $row['hersteller'] );
           open_td( '', '', price_view( $netto ) );
           if( $have_mwst ) {
             $mwst = $row['mwst'];
@@ -233,6 +238,7 @@ open_fieldset( 'small_form', '', $produkt_id ?  "Katalogsuche nach Artikelnummer
             open_td( 'mult', '', price_view( $mwst ) );
             open_td( 'mult', '', price_view( $brutto ) );
           }
+          open_td( '', '', ean_view( $row['ean_einzeln']).ean_links($row['ean_einzeln']) );
           open_td( '', '',  "{$row['katalogtyp']} / {$row['katalogdatum']}" );
           if( ! $produkt_id ) {
             open_td( 'center' );

--- a/windows/bestellen.php
+++ b/windows/bestellen.php
@@ -557,6 +557,11 @@ foreach( $produkte as $produkt ) {
   , $verteilmult
   );
   $produktgruppe = $produkt['produktgruppen_id'];
+  
+  $katalogeintrag = katalogsuche($produkt_id);
+  if (! is_array( $katalogeintrag ) ) // not found
+    $katalogeintrag = array();
+  
   if( $produktgruppe != $produktgruppe_alt ) {
     if( 0 * $activate_mozilla_kludges ) {
       // mozilla can't handle rowspan in complex tables on first pass (grid lines get lost),
@@ -574,9 +579,10 @@ foreach( $produkte as $produkt ) {
   hidden_input( "toleranz_$n", "$toleranzmenge", "id='toleranz_$n'" );
 
   open_td();
-    open_div('oneline', '', $produkt['produkt_name']);
+    open_span('oneline', '', $produkt['produkt_name']);
+    open_span('small floatright', 'title="Quelle: Lieferantenkatalog"', catalogue_product_details($katalogeintrag) );
     open_div('small', '', $produkt['notiz']);
-
+    
   // preis:
   $class = '';
   $title = '';

--- a/windows/bestellen.php
+++ b/windows/bestellen.php
@@ -559,8 +559,6 @@ foreach( $produkte as $produkt ) {
   $produktgruppe = $produkt['produktgruppen_id'];
   
   $katalogeintrag = katalogsuche($produkt_id);
-  if (! is_array( $katalogeintrag ) ) // not found
-    $katalogeintrag = array();
   
   if( $produktgruppe != $produktgruppe_alt ) {
     if( 0 * $activate_mozilla_kludges ) {

--- a/windows/katalog_upload.php
+++ b/windows/katalog_upload.php
@@ -21,11 +21,18 @@ open_div( '', '', "Katalog einlesen: Lieferant: {$lieferant['name']} / g&uuml;lt
 
 function katalog_update(
   $lieferant_id, $tag, $katalogkw
-, $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, $katalogformat
+, $anummer, $bnummer, $name, $bemerkung, $einheit, $gebinde, $mwst, $pfand
+, $hersteller, $verband, $herkunft
+, $netto
+, $ean_einzeln
+, $katalogformat
 ) {
 
   open_div( 'ok' );
-    open_div( 'ok qquad', '', "erfasst: $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, $katalogformat" );
+    open_div( 'ok qquad', '', 
+            "erfasst: $anummer, $bnummer, $name, $bemerkung, $einheit, "
+            . "$gebinde, $mwst, $pfand, $hersteller, $verband, $herkunft, "
+            . "$netto, $ean_einzeln, $katalogformat" );
   close_div();
 
   doSql( "
@@ -45,6 +52,9 @@ function katalog_update(
     , katalogtyp
     , katalogformat
     , gueltig
+    , hersteller
+    , bemerkung
+    , ean_einzeln
     ) VALUES (
       '$lieferant_id'
     , '$anummer'
@@ -61,6 +71,9 @@ function katalog_update(
     , '$tag'
     , '$katalogformat'
     , 1
+    , '$hersteller'
+    , '$bemerkung'
+    , '$ean_einzeln'
     ) ON DUPLICATE KEY UPDATE
       bestellnummer='$bnummer'
     , name='$name'
@@ -75,6 +88,9 @@ function katalog_update(
     , katalogtyp='$tag'
     , katalogformat='$katalogformat'
     , gueltig=1
+    , hersteller='$hersteller'
+    , bemerkung='$bemerkung'
+    , ean_einzeln='$ean_einzeln'
   " );
 }
 
@@ -210,14 +226,17 @@ function upload_terra() {
     $anummer = "";
     $bnummer = "";
     $name = "";
+    $bemerkung = "";
     $einheit = "";
     $gebinde = "";
     $mwst = "7.00";
     $pfand = "0.00";
+    $hersteller = "";
     $verband = "";
     $herkunft = "";
     $netto = "0.00";
     $vpe = "";
+    $ean_einzeln = "";
 
     $i=0;
     foreach( $splitline as $field ) {
@@ -249,7 +268,7 @@ function upload_terra() {
     }
 
     katalog_update( $lieferanten_id, $tag, $katalogkw
-    , $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, 'terra_xls'
+    , $anummer, $bnummer, $name, $bemerkung, $einheit, $gebinde, $mwst, $pfand, $hersteller, $verband, $herkunft, $netto, $ean_einzeln, 'terra_xls'
     );
     $success++;
   }
@@ -281,13 +300,16 @@ function upload_rapunzel() {
     $anummer = "";
     $bnummer = "";
     $name = "";
+    $bemerkung = "";
     $einheit = "";
     $gebinde = "";
     $mwst = "-1";
     $pfand = "0.00";
+    $hersteller = "";
     $verband = "";
     $herkunft = "";
     $netto = "0.00";
+    $ean_einzeln = "";
 
     $splitline = preg_split( $splitat, $line );
 
@@ -314,7 +336,7 @@ function upload_rapunzel() {
     $einheit = "$m $e";
 
     katalog_update( $lieferanten_id, $tag, $katalogkw
-    , $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, 'rapunzel'
+    , $anummer, $bnummer, $name, $bemerkung, $einheit, $gebinde, $mwst, $pfand, $hersteller, $verband, $herkunft, $netto, $ean_einzeln, 'rapunzel'
     );
     $success++;
   }
@@ -346,13 +368,16 @@ function upload_bode() {
     $anummer = "";
     $bnummer = "";
     $name = "";
+    $bemerkung = "";
     $einheit = "";
     $gebinde = "";
     $mwst = "-1";
     $pfand = "0.00";
+    $hersteller = "";
     $verband = "";
     $herkunft = "";
     $netto = "0.00";
+    $ean_einzeln = "";
 
     $splitline = preg_split( $splitat, $line );
     $bnummer = $splitline[1];
@@ -385,7 +410,7 @@ function upload_bode() {
     $einheit = "$m $e";
 
     katalog_update( $lieferanten_id, $tag, $katalogkw
-    , $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, 'bode'
+    , $anummer, $bnummer, $name, $bemerkung, $einheit, $gebinde, $mwst, $pfand, $hersteller, $verband, $herkunft, $netto, $ean_einzeln, 'bode'
     );
     $success++;
   }
@@ -403,7 +428,8 @@ function upload_bode() {
 //                       4 ean?
 //                                     5 ?
 //                                      6 name
-//                                                             7 8 9 ?
+//                                                             7 bemerkung
+//                                                               8 9 ?
 //                                                                   10 hersteller
 //                                                                    11?
 //                                                                     12 land
@@ -451,7 +477,8 @@ function upload_bode() {
 //                                     5 ?
 //                                      6 name
 //                                                             7 8 9 ?
-//                                                                  11?
+//                                                                  10 hersteller
+//                                                                    11?
 //                                                                     12 land
 //                                                                       13 verband
 //                                                                             14 ...                20  ?
@@ -553,6 +580,8 @@ function upload_bnn( $katalogformat ) {
     $anummer = "";
     $bnummer = "";
     $name = "";
+    $bemerkung = "";
+    $handelsklasse = "";
     $einheit = "";
     $gebinde = "";
     $mwst = "-1";
@@ -560,15 +589,30 @@ function upload_bnn( $katalogformat ) {
     $verband = "";
     $herkunft = "";
     $netto = "0.00";
+    $hersteller = "";
+    $ean_einzeln = "";
 
     $bnummer = $splitline[0];
     $bnummer = mysql_real_escape_string( preg_replace( '/\s/', '', $bnummer ) );
     $anummer = $bnummer;
 
     $name = mysql_real_escape_string( $splitline[6] );
+    $bemerkung = mysql_real_escape_string( $splitline[7] );
+    $handelsklasse = mysql_real_escape_string( $splitline[9] );
     $herkunft = mysql_real_escape_string( $splitline[12] );
     $verband = mysql_real_escape_string( $splitline[13] );
-
+    $hersteller = mysql_real_escape_string( $splitline[10] );
+    $ean_einzeln = mysql_real_escape_string( $splitline[4] );
+    
+    if ( $handelsklasse )
+    {
+        $handelsklasse = "HK $handelsklasse";
+        if ( $bemerkung )
+            $bemerkung = "$handelsklasse; $bemerkung";
+        else
+            $bemerkung = $handelsklasse;
+    }
+    
     $gebinde = $splitline[22];
     $gebinde = preg_replace( '/,/', '.', trim( $gebinde ) );
     $gebinde = sprintf( '%.2f', $gebinde );
@@ -607,7 +651,7 @@ function upload_bnn( $katalogformat ) {
     $einheit = "$m $e";
 
     katalog_update( $lieferanten_id, $tag, $katalogkw
-    , $anummer, $bnummer, $name, $einheit, $gebinde, $mwst, $pfand, $verband, $herkunft, $netto, $katalogformat
+    , $anummer, $bnummer, $name, $bemerkung, $einheit, $gebinde, $mwst, $pfand, $hersteller, $verband, $herkunft, $netto, $ean_einzeln, $katalogformat
     );
     $success++;
   }

--- a/windows/produkte.php
+++ b/windows/produkte.php
@@ -113,6 +113,8 @@ open_table('list hfill');
     $produkt = sql_produkt( array( 'produkt_id' => $id, 'preis_id' => $preis_id ) );
     $references = references_produkt( $id );
     $vormerkungen_menge = sql_bestellzuordnung_menge( array( 'art' => BESTELLZUORDNUNG_ART_VORMERKUNGEN, 'produkt_id' => $id ) );
+    
+    $katalogeintrag = katalogsuche( $p );
 
     open_tr( 'groupofrows_top' );
       $produktgruppen_id = $produkt['produktgruppen_id'];
@@ -122,7 +124,8 @@ open_table('list hfill');
         $produktgruppen_id_alt = $produktgruppen_id;
       }
       open_td( 'top' );
-        open_div( 'bold', '', $produkt['name'] );
+        open_span( 'bold', '', $produkt['name'] );
+        open_span( 'small floatright', '', catalogue_product_details( $katalogeintrag ));
         open_div( 'small', '', $produkt['notiz'] );
       if( $editable ) {
         if( $preis_id ) {


### PR DESCRIPTION
Hallo!

Ich hab hier zwei Commits, die dazu da sind, Infos aus dem Lieferantenkatalog direkt in der Bestellvorlage anzuzeigen. Der Vorteil wäre, dass seltener die Notiz veraltet, in die ja bislang oft Herkunft und Verband kopiert wird und manchmal passiert beim Preis-Update, dass sie nicht mit aktualisiert wird. Und dann gibt's mitten im Winter scheinbar "regionale Erdbeeren" oder so...

Der erste Commit zeigt einfach Herkunft und Verband rechts oben in jeder Produktzeile an.

Der zweite Commit führt neue Felder in lieferantenkatalog ein: Bemerkung, Hersteller und EAN, die ebenfalls in der Bestellvorlage angezeigt werden. Für die EAN werden Links zu Google bzw. barcoo generiert. Zudem wird die Handelsklasse, falls vorhanden, in die BNN-Bemerkung übernommen.

Der zweite Commit bedingt auch eine DB-Schema-Änderung.

Was man noch machen könnte, ist, dass man Tabellen einführt, die Herkunft, Verband und evtl. Hersteller von 3-Buchstaben-Akronymen auf volle Namen umsetzt.

Sagt mal, was ihr davon haltet. Ich find's sehr praktisch.

Tilman
