### PR TITLE
IP Validierung für proxie/cluster topologien angepasst SETUP.PHP

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -18,7 +18,17 @@
 
 require_once('code/config.php');
 
+
+  // proof ips behind proxies, dont blame proxies.
 $remote_ip = getenv('REMOTE_ADDR');
+if (filter_var($remote_ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false){
+  foreach (array( 'HTTP_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_FORWARDED') as $pos){
+    if (array_key_exists($pos, $_SERVER) === true){
+      $remote_ip = getenv($pos);
+    }
+  }
+}
+  
 if( $allow_setup_from and preg_match( '/^'.$allow_setup_from.'/', $remote_ip ) ) {
   true;
 } else {


### PR DESCRIPTION
Hallo hier Elias vom likk.de, habe beim aufsetzen eurer Software unter anderem diese Ergänzung vorgenommen. Weitere folgen.
setup.php verwendet externe(wan) Adresse anstatt interne gateway(proxie) Addresse zur Validierung.