### PR TITLE
Erlaube Konfiguration der MwSt-Sätze beim Katalog-Import (database_version 37) und SQL-Skript zu Konvertierung aktueller Preise

### DIFF
--- a/code/zuordnen.php
+++ b/code/zuordnen.php
@@ -4973,6 +4973,7 @@ function tex2pdf( $tex ) {
     // open_div( 'ok', '', 'ok: '.  implode( ' ', $output ) );
   } else {
     open_div( 'warn', '', 'error: '. file_get_contents( 'tex2pdf.log' ) );
+    open_div( 'warn', '', 'tex: ' . file_get_contents( 'tex2pdf.tex' ) );
     $pdf = false;
   }
   @ unlink( 'tex2pdf.tex' );
@@ -4990,12 +4991,10 @@ function tex_encode( $s ) {
     '/\\\\/' => '\\backslash'
   , '/\\&quot;/' => "''"
   , '/\\&#039;/' => "'"
-  , '/([$%_#~])/' => '\\\\$1'
+  , '/([$%_#~{}])/' => '\\\\$1'
   , '/\\&amp;/' => '\\&'
-  , '/\\&lt;/' => '$<$'
-  , '/\\&gt;/' => '$>$'
-  , '/[}]/' => '$\}$'
-  , '/[{]/' => '$\{$'
+  , '/\\&lt;/' => '\textless'
+  , '/\\&gt;/' => '\textgreater'
   , '/ä/' => '{\"a}'
   , '/Ä/' => '{\"A}'
   , '/ö/' => '{\"o}'

--- a/code/zuordnen.php
+++ b/code/zuordnen.php
@@ -4854,6 +4854,22 @@ function update_database( $version ) {
 
       sql_update( 'leitvariable', array( 'name' => 'database_version' ), array( 'value' => 36 ) );
       logger( 'update_database: update to version 36 successful' );
+  case 36:
+      logger( 'starting update_database: from version 36' );
+
+      sql_insert( 'leitvariable', array(
+        'name' => 'katalog_mwst_reduziert'
+      , 'value' => '7.00'
+      , 'comment' => 'Reduzierter MwSt-Satz beim BNN-Import'
+      ) );
+      sql_insert( 'leitvariable', array(
+        'name' => 'katalog_mwst_standard'
+      , 'value' => '19.00'
+      , 'comment' => 'Standard-MwSt-Satz beim BNN-Import'
+      ) );
+
+      sql_update( 'leitvariable', array( 'name' => 'database_version' ), array( 'value' => 37 ) );
+      logger( 'update_database: update to version 37 successful' );
   }
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,6 +24,7 @@ chmod 644 README.md
 chmod 644 ToDo.txt
 chmod 755 antixls.modif
 chmod 644 apache.sample.conf
+chmod 644 catalogue_acronyms.sql
 chmod 644 code/common.php
 chmod 644 code/config.php
 chmod 644 code/err_functions.php
@@ -85,6 +86,7 @@ chmod 644 js/tooltip.js
 chmod 644 leitvariable.php
 chmod 644 links_und_parameter
 chmod 755 setup.php
+chmod 644 sql/mwst.sql
 chmod 644 structure.php
 chmod 644 templates/bestellschein.tex
 chmod 644 templates/prettytables.tex

--- a/leitvariable.php
+++ b/leitvariable.php
@@ -105,6 +105,22 @@ $leitvariable = array(
   , 'runtime_editable' => 1
   , 'cols' => '8'
   )
+, 'katalog_mwst_reduziert' => array(
+    'meaning' => 'Reduzierter MwSt-Satz beim BNN-Import'
+  , 'comment' => 'H&auml;ufigster Mehrwertsteuer-Satz auf Lebensmittel in Prozent'
+  , 'default' => '7.00'
+  , 'local' => false
+  , 'runtime_editable' => 1
+  , 'cols' => '8'
+  )
+, 'katalog_mwst_standard' => array(
+    'meaning' => 'Standard MwSt-Satz beim BNN-Import'
+  , 'comment' => 'Standard-Mehrwertsteuer-Satz in Prozent'
+  , 'default' => '19.00'
+  , 'local' => false
+  , 'runtime_editable' => 1
+  , 'cols' => '8'
+  )
 , 'toleranz_default' => array(
     'meaning' => 'Default-Toleranz-Satz'
   , 'comment' => 'automatischer Toleranzzuschlag in Prozent bei Bestellungen (kann im Einzelfall manuell runtergesetzt werden)'

--- a/sql/mwst.sql
+++ b/sql/mwst.sql
@@ -1,0 +1,89 @@
+/*
+ * Mit diesem Skript kann man alle aktuellen Preiseinträge zu einem definierten
+ * Termin auf neue MwSt-Sätze umstellen.
+ *
+ * Für Bestellungen, deren Liefertermin nach dem Termin liegt, werden diese
+ * neuen Preiseinträge gesetzt, sofern sie noch auf Preiseinträge mit altem
+ * MwSt-Satz verweisen.
+ *
+ * Verwendung:
+ *
+ * 1. Backup der Datenbank machen:
+ * # mysqldump <DATABASENAME> | bzip2 > backup.sql.bz2
+ *
+ * 2. Skript konfigurieren (falls nötig):
+ * # vi mwst.sql
+ *
+ * 3. Skript ausführen:
+ * # mysql <DATABASENAME> < mwst.sql
+ *
+ * 4. Fertig :-D
+ *
+ * Bemerkungen:
+ * Dieses Skript ist (hoffentlich) idempotent, kann also mehrfach ausgeführt werden und hat nur beim
+ * ersten Mal einen Effekt.
+ *
+ * Sollte einem eine Bestellung durch die Lappen gegangen sein, weil das Lieferdatum vor dem
+ * Stichtag lag, kann man das Lieferdatum ändern und das Skript nochmal laufen lassen, um diese
+ * Bestellung nachträglich zu konvertieren.
+ */
+
+/*
+ * Skript-Konfiguration:
+ */
+set @old1 = 7, @new1 = 5, @old2 = 19, @new2 = 16;
+set @changetime = timestamp('2020-07-01 00:00:00');
+
+/*
+ * Ausführung:
+ */
+select concat('Suche aktuelle Preiseinträge mit MwSt ', @old1, '% oder ', @old2, '%:') as '';
+
+drop table if exists new_produktpreise;
+create temporary table new_produktpreise as select * from produktpreise
+    where mwst in (@old1, @old2)
+    and zeitende is null;
+select concat(row_count(), ' gefunden.') as '';
+alter table new_produktpreise modify id int(11) null;
+
+drop table if exists updated_produktpreise;
+create temporary table updated_produktpreise as select * from new_produktpreise;
+alter table updated_produktpreise modify id int(11) null;
+
+select 'Schließe aktuelle Preiseinträge ab.' as '';
+update updated_produktpreise set zeitende=timestampadd(SECOND, -1, @changetime);
+
+select 'Erzeuge neue Preiseinträge.' as '';
+update new_produktpreise set
+    id=NULL,
+    zeitstart=@changetime,
+    mwst=
+    case
+        when mwst = @old1 then @new1
+        when mwst = @old2 then @new2
+        else mwst
+    end;
+
+select 'Pflege Änderungen ein.' as '';
+update produktpreise as d, updated_produktpreise as s set d.zeitende = s.zeitende where d.id = s.id;
+insert into produktpreise select * from new_produktpreise;
+
+select 'Aktualisiere Preiseinträge in aktuellen Bestellungen' as '';
+update bestellvorschlaege as d,
+    /* erste Referenz um den korrekten neuen Eintrag zu selektieren */
+    produktpreise as s,
+    /* zweite Referenz, um zu überprüfen dass der alte Eintrag noch falsch ist */
+    produktpreise as c,
+    gesamtbestellungen as g
+    set d.produktpreise_id = s.id
+    where s.produkt_id = d.produkt_id
+        and s.zeitende is null
+        and c.id = d.produktpreise_id
+        and c.mwst in (@old1, @old2)
+        and d.gesamtbestellung_id = g.id
+        and g.lieferung >= @changetime;
+
+select concat(row_count(), ' Einträge aktualisiert.') as '';
+
+select 'Fertig :-)' as '';
+

--- a/templates/bestellschein.tex
+++ b/templates/bestellschein.tex
@@ -3,6 +3,7 @@
 \usepackage{eurosym}
 \usepackage{german}
 \usepackage{color}
+\usepackage[T1]{fontenc}
 
 \definecolor{mygray}{cmyk}{0,0,0,0.1}
 \def\normalfont{\sffamily}

--- a/windows/bestellfax.php
+++ b/windows/bestellfax.php
@@ -88,10 +88,11 @@ if( isset( $download ) && ( $download == 'bestellfax' ) ) {
   }
   $tex = preg_replace( '/@@tabelle@@/', bestellfax_tex( $bestell_id, $spalten ), $tex );
   // file_put_contents( '/tmp/b.tex', $tex );
+  //header("Content-Type: text/plain");
+  //echo $tex;
+  //return;
   if( ( $pdf = tex2pdf( $tex ) ) ) {
     $downloadname = 'Bestellschein.pdf';
-    // header("Content-Type: text/plain");
-    // echo $tex;
     header( 'Content-Type: application/pdf' );
     header( "Content-Disposition: filename=$downloadname" );
     echo $pdf;

--- a/windows/katalog_upload.php
+++ b/windows/katalog_upload.php
@@ -113,7 +113,7 @@ function katalog_update(
 
 
 function upload_terra() {
-  global $db_handle, $katalogkw, $lieferanten_id, $lieferant;
+  global $db_handle, $katalogkw, $lieferanten_id, $lieferant, $katalog_mwst_standard, $katalog_mwst_reduziert;
 
   exec( './antixls.modif -c 2>/dev/null ' . $_FILES['katalog']['tmp_name'], $klines );
 
@@ -516,7 +516,7 @@ function upload_bode() {
 // und um mit der existierenden datenbank kompatibel zu bleiben:
 //
 function upload_bnn( $katalogformat ) {
-  global $db_handle, $katalogkw, $lieferanten_id, $lieferant;
+  global $db_handle, $katalogkw, $lieferanten_id, $lieferant, $katalog_mwst_standard, $katalog_mwst_reduziert;
 
   $klines = file( $_FILES['katalog']['tmp_name'] );
 

--- a/windows/katalog_upload.php
+++ b/windows/katalog_upload.php
@@ -246,7 +246,7 @@ function upload_terra() {
     $bemerkung = "";
     $einheit = "";
     $gebinde = "";
-    $mwst = "7.00";
+    $mwst = $katalog_mwst_reduziert;
     $pfand = "0.00";
     $hersteller = "";
     $verband = "";
@@ -654,10 +654,10 @@ function upload_bnn( $katalogformat ) {
 
     switch( trim( $splitline[33] ) ) {
       case '1':
-        $mwst = "7.00";
+        $mwst = $katalog_mwst_reduziert;
         break;
       case '2':
-        $mwst = "19.00";
+        $mwst = $katalog_mwst_standard;
         break;
       default:
         break;


### PR DESCRIPTION
Neue Leitvariablen katalog_mwst_{reduziert,standard};

katalog_upload.php: Benutze neue Leitvariablen.